### PR TITLE
fix a bug in `Manager.unregister`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.swp
 *.egg-info
+.DS_Store
+

--- a/tests/test_xdeps.py
+++ b/tests/test_xdeps.py
@@ -5,44 +5,45 @@
 
 import xdeps
 
+
 def test_set():
-    v={'a':1, 'b':3}
-    mgr=xdeps.Manager()
-    r=mgr.ref(v)
-    r['c']=0.1*r['a']+0.2*r['b']
-    assert v['c']==0.1*v['a']+0.2*v['b']
-    r['a']=1.2
-    assert v['c']==0.1*v['a']+0.2*v['b']
+    v = {'a': 1, 'b': 3}
+    mgr = xdeps.Manager()
+    r = mgr.ref(v)
+    r['c'] = 0.1 * r['a'] + 0.2 * r['b']
+    assert v['c'] == 0.1 * v['a'] + 0.2 * v['b']
+    r['a'] = 1.2
+    assert v['c'] == 0.1 * v['a'] + 0.2 * v['b']
 
 
 def test_attrref():
     class E:
         pass
 
-    e=E()
-    e.knl=[0,1,2,3]
-    v={4:e,2:1.2}
+    e = E()
+    e.knl = [0, 1, 2, 3]
+    v = {4: e, 2: 1.2}
 
-    mgr=xdeps.Manager()
-    v_=mgr.ref(v,'v')
-    v_[4].knl[1]=v_[2]*3
+    mgr = xdeps.Manager()
+    v_ = mgr.ref(v, 'v')
+    v_[4].knl[1] = v_[2] * 3
 
-    assert v[4].knl[1]==v[2]*3
-    v_[2]=1.1
-    assert v[4].knl[1]==v[2]*3
+    assert v[4].knl[1] == v[2] * 3
+    v_[2] = 1.1
+    assert v[4].knl[1] == v[2] * 3
 
 
 def test_inplace():
-    m=xdeps.Manager()
+    m = xdeps.Manager()
 
-    s={'a': 1, 'b': 2}
-    s_=m.ref(s,'s')
+    s = {'a': 1, 'b': 2}
+    s_ = m.ref(s, 's')
     s_._exec('c=a+b')
-    assert s['c']==s['a']+s['b']
-    s_['c']+=1 ## s_['a']= s_['c']._expr + 1
-    assert s['c']==s['a']+s['b']+1
-    s_['a']+=1 ## s_['a']= s['a'] + 1
-    assert s['c']==s['a']+s['b']+1
+    assert s['c'] == s['a'] + s['b']
+    s_['c'] += 1  ## s_['a']= s_['c']._expr + 1
+    assert s['c'] == s['a'] + s['b'] + 1
+    s_['a'] += 1  ## s_['a']= s['a'] + 1
+    assert s['c'] == s['a'] + s['b'] + 1
 
 
 def test_unregister_implicit():

--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -822,7 +822,7 @@ class RefList:
         self.list.append(item)
 
     def remove(self, item):
-        self.list.pop(self.index(item))
+        del self[self.index(item)]
 
 
 gbl = globals()

--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -779,6 +779,52 @@ class CallRef(ARef):
         return f"{fname}({args})"
 
 
+class RefList:
+    """
+    A list implementation that does not use __eq__ for comparisons. It is used
+    for storing tasks, which need to be compared by their hash, as the usual
+    == operator yields an expression, which is always True.
+    """
+    def __init__(self, *args, **kwargs):
+        self.list = list(*args, **kwargs)
+
+    def __repr__(self):
+        return f"RefList({self.list})"
+
+    def __contains__(self, item):
+        try:
+            self.index(item)
+            return True
+        except ValueError:
+            return False
+
+    def __getitem__(self, item):
+        return self.list[item]
+
+    def __delitem__(self, index):
+        self.list.pop(index)
+
+    def __iter__(self):
+        return iter(self.list)
+
+    def index(self, item):
+        for ii, x in enumerate(self.list):
+            if hash(item) == hash(x):
+                return ii
+        raise ValueError(f'{item} is not in list')
+
+    def extend(self, other):
+        if isinstance(other, RefList):
+            other = other.list
+        self.list.extend(other)
+
+    def append(self, item):
+        self.list.append(item)
+
+    def remove(self, item):
+        self.list.pop(self.index(item))
+
+
 gbl = globals()
 for st, op in _binops.items():
     fn = op.__name__.replace("_", "")

--- a/xdeps/tasks.py
+++ b/xdeps/tasks.py
@@ -128,7 +128,7 @@ class Manager:
 
     tasks: taskid -> task
     rdeps: ref -> set of all refs that depends on `ref`
-    rtasks: taskid -> set all tasks whose dependencies are affected by taskid
+    rtasks: taskid -> all tasks whose dependencies are affected by taskid
     deptasks: ref -> all tasks that has ref as dependency
     tartasks: ref -> all tasks that has ref as target
     containers: label -> controlled container
@@ -200,7 +200,7 @@ class Manager:
             for target in task.targets:
                 if target in self.rdeps[dep]:
                     self.rdeps[dep].remove(target)
-            if dep in self.rtasks[dep]:
+            if taskid in self.rtasks[dep]:
                 self.rtasks[dep].remove(taskid)
             if taskid in self.deptasks[dep]:
                 self.deptasks[dep].remove(taskid)

--- a/xdeps/tasks.py
+++ b/xdeps/tasks.py
@@ -8,8 +8,7 @@ from collections import defaultdict
 import logging
 from copy import deepcopy
 
-from .refs import ARef, Ref, ObjectAttrRef
-from .refs import AttrRef, CallRef, ItemRef
+from .refs import ARef, CallRef, Ref, ObjectAttrRef, RefList
 from .utils import os_display_png, mpl_display_png, ipy_display_png
 from .utils import AttrDict
 from .sorting import toposort
@@ -138,10 +137,10 @@ class Manager:
     def __init__(self):
         self.tasks = {}
         self.containers = {}
-        self.rdeps = defaultdict(list)
-        self.rtasks = defaultdict(list)
-        self.deptasks = defaultdict(list)
-        self.tartasks = defaultdict(list)
+        self.rdeps = defaultdict(RefList)
+        self.rtasks = defaultdict(RefList)
+        self.deptasks = defaultdict(RefList)
+        self.tartasks = defaultdict(RefList)
 
     def ref(self, container=None, label="_"):
         """Return a ref to an instance (or dict) associated to a label.


### PR DESCRIPTION
## Description

This fixes an issue where `Manager.unregister` deletes wrong entries in `mgr.deptasks`, among others. This is caused by the fact that `list.remove`, `list.__contains__`, and similar methods perform comparisons using [`(x is y or x == y)`](https://docs.python.org/3/reference/expressions.html#membership-test-details), which in our case would always return true if the elements of the list are Refs.

This PR introduces a `RefList` container that has the 'correct' behaviour.

An example of the offending situation:

```python
mgr = xdeps.Manager()

container = {
    'a': 1,
    'b': 2,
    'c': {
        'x': 4,
        'y': 6,
    }
}

ref = mgr.ref(container, 'ref')
ref['c']['x'] = 2 * ref['a'] * ref['b']
ref['c']['y'] = 3 * ref['a'] * ref['b']

ref['a'] = 2
ref['b'] = 2

assert container['c']['x'] == 8
assert container['c']['y'] == 12

mgr.unregister(ref['c']['y'])

ref['a'] = 1  # ==> Throws KeyError: ref['c']['y']

assert container['c']['x'] == 4
assert container['c']['y'] == 12  # should be unchanged
```

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
