### PR TITLE
fix dict_keys has no remove method error on _col_names in table

### DIFF
--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -180,7 +180,7 @@ class Table:
     ):
         self._data = data
 
-        self._col_names = list(data.keys()) if col_names is None else col_names
+        self._col_names = list(data.keys() if col_names is None else col_names)
         for kk in self._col_names:
             vv = data[kk]
             if not hasattr(vv, 'dtype'):


### PR DESCRIPTION
## Description

This is small bugfix to make sure that the _col_names field in table is actually a list (even if it is initialised from dict_keys).

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
