### PR TITLE
Ensure list type

### DIFF
--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -404,7 +404,7 @@ class Table:
 
         # select cols
         if cols is None or cols == slice(None, None, None):
-            col_list = self._col_names
+            col_list = list(self._col_names)
         elif type(cols) is str:
             col_list = cols.split()
         else:


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Ensure the function returns an object of type list.

This fixes an issue with
```python
line = ...
line.build_tracker()
survey = line.survey()
print(survey)
```
throwing
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File ~/.local/lib/python3.8/site-packages/IPython/core/formatters.py:706, in PlainTextFormatter.__call__(self, obj)
    699 stream = StringIO()
    700 printer = pretty.RepresentationPrinter(stream, self.verbose,
    701     self.max_width, self.newline,
    702     max_seq_length=self.max_seq_length,
    703     singleton_pprinters=self.singleton_printers,
    704     type_pprinters=self.type_printers,
    705     deferred_pprinters=self.deferred_printers)
--> 706 printer.pretty(obj)
    707 printer.flush()
    708 return stream.getvalue()

File ~/.local/lib/python3.8/site-packages/IPython/lib/pretty.py:410, in RepresentationPrinter.pretty(self, obj)
    407                         return meth(obj, self, cycle)
    408                 if cls is not object \
    409                         and callable(cls.__dict__.get('__repr__')):
--> 410                     return _repr_pprint(obj, self, cycle)
    412     return _default_pprint(obj, self, cycle)
    413 finally:

File ~/.local/lib/python3.8/site-packages/IPython/lib/pretty.py:778, in _repr_pprint(obj, p, cycle)
    776 """A pprint that just redirects to the normal repr function."""
    777 # Find newlines and replace them with p.break_()
--> 778 output = repr(obj)
    779 lines = output.splitlines()
    780 with p.group():

File ~/.local/lib/python3.8/site-packages/xdeps/table.py:359, in Table.__repr__(self)
    357 out = [f"{self.__class__.__name__}: {n} row{ns}, {c} col{cs}"]
    358 if self._nrows < 10000:
--> 359     show = self.show(output=str)
    360     out.append(show)
    361 return "\n".join(out)

File ~/.local/lib/python3.8/site-packages/xdeps/table.py:466, in Table.show(self, rows, cols, maxrows, maxwidth, output, digits, fixed, header, max_col_width)
    464 # index always first
    465 if self._index in col_list:
--> 466     col_list.remove(self._index)
    467 col_list.insert(0, self._index)
    469 cut = -1

AttributeError: 'dict_keys' object has no attribute 'remove'
```


## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
