### PR TITLE
Print only shapes of array fields in table and put them at end

### DIFF
--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -1,6 +1,8 @@
 import os
 import pathlib
 import re
+from typing import Collection
+
 import numpy as np
 
 gblmath = {"np": np}
@@ -40,6 +42,17 @@ def _to_str(arr, digits, fixed="g", max_len=None):
         # each element.
         fmt = "%%.%d%s" % (digits, fixed)
         out = np.char.mod(fmt, arr)
+    elif arr.dtype.kind == "O" and isinstance(arr[0], Collection):
+        # If array of collections (array with dtype=object) or list, give shape
+        lengths = []
+        for entry in arr:
+            if isinstance(entry, np.ndarray):
+                lengths.append(f'<array of shape {entry.shape}>')
+            elif isinstance(entry, Collection):
+                lengths.append(f'<collection of length {len(entry)}>')
+            else:
+                lengths.append(str(entry))
+        out = np.array(lengths)
     else:
         # Any other flat array: stringify.
         out = arr.astype(f'U')


### PR DESCRIPTION
## Description

When printing the twiss table, show fields containing matrices as `<array of shape (...)>` as opposed to printing a long multiline entry. If desired columns are not specified when showing the table, put the array fields at the end to make room for more detailed information.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
