### PR TITLE
Handle inexistent ref values better

### DIFF
--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -129,6 +129,28 @@ def test_builtin_expression():
     # assert float(lhs)._get_value() == float(7)
 
 
+def test_handle_inexistent_values():
+    manager = tasks.Manager()
+    container = {
+        'dict': {},
+        'object': object(),
+    }
+    ref = manager.ref(container, 'ref')
+
+    with pytest.raises(AttributeError):
+        ref['object'].not_there._get_value()
+
+    with pytest.raises(BaseException):
+        # See the comment in BaseRef._value for why it's not an AttributeError
+        _ = ref['object'].not_there_either._value
+
+    with pytest.raises(KeyError):
+        ref['dict']['not there']._get_value()
+
+    with pytest.raises(KeyError):
+        _ = ref['dict']['not there either']._value
+
+
 @pytest.mark.xfail(reason='Undefined behaviour')
 def test_ref_inplace_ops():
     manager = tasks.Manager()


### PR DESCRIPTION
## Description

- When inspecting a ref with `_info()` show more clearly that the ref points to an non-existent variable.
- Make the behaviour of `_value` the same as `_get_value()`, i.e. give an error when the ref points to a non-existent field. Up until now `_value` would not give an error due to the way Python handles the interplay between `@properties` and `__getattr__`.

Requires #39.
Closes xsuite/xsuite#427.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
