### PR TITLE
Xdeps release/v0.5.0

### DIFF
--- a/examples/ex_plot.py
+++ b/examples/ex_plot.py
@@ -6,23 +6,28 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-a=1;b=1;c=0
-x=np.arange(0,3.,.1)
-y=a*np.sin(b*x+c)
-pl,=plt.plot(x,y)
+import xdeps
 
-def update(pl,x,y):
+a = 1
+b = 1
+c = 0
+x = np.arange(0, 3., .1)
+y = a * np.sin(b * x + c)
+pl, = plt.plot(x, y)
+
+
+def update(pl, x, y):
     pl.set_xdata(x)
     pl.set_ydata(y)
 
-import xdeps
-mgr=xdeps.Manager()
-gbl=mgr.refattr(globals(),'gbl')
 
-gbl._eval('y=a*np.sin(b*x+c)')
-gbl._eval('myup=update(pl,x,y)')
+mgr = xdeps.Manager()
+gbl = mgr.refattr(globals(), 'gbl')
 
-gbl.a=2.1
-gbl.x[3]=2.1
+gbl._exec('y=a*np.sin(b*x+c)')
+gbl._exec('myup=update(pl,x,y)')
 
-mgr.to_pydot([gbl.x])
+gbl.a = 0.2
+gbl.x[3] = 2.1
+
+mgr.plot_deps(backend='os')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
 
+from Cython.Build import cythonize
 from setuptools import setup, find_packages
 from pathlib import Path
 
@@ -13,24 +14,26 @@ with open(version_file.absolute(), 'r') as fp:
 __version__ = dd['__version__']
 
 setup(
-        name='xdeps',
-        version=__version__,
-        description='Data dependency manager',
-        long_description=("Data dependency manager\n"
-                         "\nThis package is part of the Xsuite collection."),
-        author='Riccardo De Maria',
-        author_email='riccardo.de.maria@cern.ch',
-        packages=find_packages(),
-        install_requires=['lark'],
-        url='https://xsuite.readthedocs.io/',
-        license='Apache 2.0',
-        download_url="https://pypi.python.org/pypi/xdeps",
-        project_urls={
-            "Bug Tracker": "https://github.com/xsuite/xsuite/issues",
-            "Documentation": 'https://xsuite.readthedocs.io/',
-            "Source Code": "https://github.com/xsuite/xdeps",
-        },
-        extras_require={
-            'tests': ['pytest'],
-        },
+    name='xdeps',
+    version=__version__,
+    description='Data dependency manager',
+    long_description=("Data dependency manager\n"
+                     "\nThis package is part of the Xsuite collection."),
+    author='Riccardo De Maria',
+    author_email='riccardo.de.maria@cern.ch',
+    packages=find_packages(),
+    install_requires=['lark', 'numpy', 'scipy', 'cython'],
+    url='https://xsuite.readthedocs.io/',
+    license='Apache 2.0',
+    download_url="https://pypi.python.org/pypi/xdeps",
+    project_urls={
+        "Bug Tracker": "https://github.com/xsuite/xsuite/issues",
+        "Documentation": 'https://xsuite.readthedocs.io/',
+        "Source Code": "https://github.com/xsuite/xdeps",
+    },
+    extras_require={
+        'tests': ['pytest'],
+    },
+    ext_modules=cythonize("xdeps/refs.py"),
+    extra_compile_args=["-O3"],
 )

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -44,8 +44,6 @@ def test_binary_expressions():
     assert (lhs < rhs)._get_value() == (7 < 13)
     assert (lhs >= rhs)._get_value() == (7 >= 13)
     assert (lhs <= rhs)._get_value() == (7 <= 13)
-    assert (lhs == rhs)._get_value() == (7 == 13)
-    assert (lhs != rhs)._get_value() == (7 != 13)
 
     # Test r-versions
     assert (7 + rhs)._get_value() == 7 + 13
@@ -64,8 +62,15 @@ def test_binary_expressions():
     assert (7 < rhs)._get_value() == (7 < 13)
     assert (7 >= rhs)._get_value() == (7 >= 13)
     assert (7 <= rhs)._get_value() == (7 <= 13)
-    assert (7 == rhs)._get_value() == (7 == 13)
-    assert (7 != rhs)._get_value() == (7 != 13)
+
+    # Equality should check expression equivalence, instead of returning an
+    # expression itself (as __eq__ implies equal hashes)
+    assert ((lhs + rhs) == (lhs + refs.PosExpr(13))) is True  # equal even if ids differ
+    assert ((lhs + rhs) != (lhs + 13)) is True  # unequal, as type(rhs) != type(13)
+    # Actual deferred equality check:
+    assert (lhs + rhs).deferred_equal(lhs + refs.PosExpr(13))._get_value() is True
+    assert (lhs + rhs).deferred_equal(lhs + 13)._get_value() is True
+    assert (lhs + rhs).deferred_equal(lhs)._get_value() is False
 
 
 def test_matmul_expression():

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -72,6 +72,10 @@ def test_binary_expressions():
     assert (lhs + rhs).eq(lhs + 13)._get_value() is True
     assert (lhs + rhs).eq(lhs)._get_value() is False
 
+    assert (lhs + rhs).neq(lhs + refs.PosExpr(13))._get_value() is False
+    assert (lhs + rhs).neq(lhs + 13)._get_value() is False
+    assert (lhs + rhs).neq(lhs)._get_value() is True
+
 
 def test_matmul_expression():
     class DummyHashableMatrix:

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -68,13 +68,13 @@ def test_binary_expressions():
     assert ((lhs + rhs) == (lhs + refs.PosExpr(13))) is True  # equal even if ids differ
     assert ((lhs + rhs) != (lhs + 13)) is True  # unequal, as type(rhs) != type(13)
     # Actual deferred equality check:
-    assert (lhs + rhs).eq(lhs + refs.PosExpr(13))._get_value() is True
-    assert (lhs + rhs).eq(lhs + 13)._get_value() is True
-    assert (lhs + rhs).eq(lhs)._get_value() is False
+    assert (lhs + rhs)._eq(lhs + refs.PosExpr(13))._get_value() is True
+    assert (lhs + rhs)._eq(lhs + 13)._get_value() is True
+    assert (lhs + rhs)._eq(lhs)._get_value() is False
 
-    assert (lhs + rhs).neq(lhs + refs.PosExpr(13))._get_value() is False
-    assert (lhs + rhs).neq(lhs + 13)._get_value() is False
-    assert (lhs + rhs).neq(lhs)._get_value() is True
+    assert (lhs + rhs)._neq(lhs + refs.PosExpr(13))._get_value() is False
+    assert (lhs + rhs)._neq(lhs + 13)._get_value() is False
+    assert (lhs + rhs)._neq(lhs)._get_value() is True
 
 
 def test_matmul_expression():

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,0 +1,222 @@
+import math
+
+import numpy as np
+import pytest
+
+from xdeps import refs, tasks
+
+
+def test_zero_divisions():
+    one = refs.PosExpr(1)
+    zero = refs.PosExpr(0)
+
+    assert np.isnan((one / zero)._get_value())
+    assert np.isnan((one // zero)._get_value())
+    assert np.isnan((one % zero)._get_value())
+
+
+def test_unary_expressions():
+    arg = refs.PosExpr(7)
+
+    assert (+arg)._get_value() == 7
+    assert (-arg)._get_value() == -7
+    assert (~arg)._get_value() == ~7
+
+
+def test_binary_expressions():
+    lhs = refs.PosExpr(7)
+    rhs = refs.PosExpr(13)
+
+    # Test standard versions
+    assert (lhs + rhs)._get_value() == 7 + 13
+    assert (lhs - rhs)._get_value() == 7 - 13
+    assert (lhs * rhs)._get_value() == 7 * 13
+    assert (lhs / rhs)._get_value() == 7 / 13
+    assert (lhs // rhs)._get_value() == 7 // 13
+    assert (lhs % rhs)._get_value() == 7 % 13
+    assert (lhs ** rhs)._get_value() == 7 ** 13
+    assert (lhs << rhs)._get_value() == 7 << 13
+    assert (lhs >> rhs)._get_value() == 7 >> 13
+    assert (lhs & rhs)._get_value() == 7 & 13
+    assert (lhs | rhs)._get_value() == 7 | 13
+    assert (lhs ^ rhs)._get_value() == 7 ^ 13
+    assert (lhs > rhs)._get_value() == (7 > 13)
+    assert (lhs < rhs)._get_value() == (7 < 13)
+    assert (lhs >= rhs)._get_value() == (7 >= 13)
+    assert (lhs <= rhs)._get_value() == (7 <= 13)
+    assert (lhs == rhs)._get_value() == (7 == 13)
+    assert (lhs != rhs)._get_value() == (7 != 13)
+
+    # Test r-versions
+    assert (7 + rhs)._get_value() == 7 + 13
+    assert (7 - rhs)._get_value() == 7 - 13
+    assert (7 * rhs)._get_value() == 7 * 13
+    assert (7 / rhs)._get_value() == 7 / 13
+    assert (7 // rhs)._get_value() == 7 // 13
+    assert (7 % rhs)._get_value() == 7 % 13
+    assert (7 ** rhs)._get_value() == 7 ** 13
+    assert (7 << rhs)._get_value() == 7 << 13
+    assert (7 >> rhs)._get_value() == 7 >> 13
+    assert (7 & rhs)._get_value() == 7 & 13
+    assert (7 | rhs)._get_value() == 7 | 13
+    assert (7 ^ rhs)._get_value() == 7 ^ 13
+    assert (7 > rhs)._get_value() == (7 > 13)
+    assert (7 < rhs)._get_value() == (7 < 13)
+    assert (7 >= rhs)._get_value() == (7 >= 13)
+    assert (7 <= rhs)._get_value() == (7 <= 13)
+    assert (7 == rhs)._get_value() == (7 == 13)
+    assert (7 != rhs)._get_value() == (7 != 13)
+
+
+def test_matmul_expression():
+    class DummyHashableMatrix:
+        def __init__(self, value):
+            self._matrix = np.array(value)
+
+        def __matmul__(self, other):
+            return DummyHashableMatrix(self._matrix @ other._matrix)
+
+        def __pos__(self):
+            return self
+
+        def __hash__(self):
+            return hash(self._matrix.tobytes())
+
+        def __eq__(self, other):
+            return np.all(self._matrix == other._matrix)
+
+    matlhs = refs.PosExpr(DummyHashableMatrix([[1, 2], [3, 4]]))
+    matrhs = refs.PosExpr(DummyHashableMatrix([[5], [6]]))
+    assert (matlhs @ matrhs)._get_value() == DummyHashableMatrix([[17], [39]])
+
+
+def test_matmul_expression_ref():
+    container = {
+        'a': np.array([[1, 2], [3, 4]]),
+        'b': np.array([[5], [6]]),
+    }
+
+    manager = tasks.Manager()
+    ref = manager.ref(container, 'ref')
+    ref['c'] = ref['a'] @ ref['b']
+
+    assert np.all(container['c'] == np.array([[17], [39]]))
+
+
+def test_builtin_expression():
+    lhs = refs.PosExpr(7)
+    rhs = refs.PosExpr(13)
+    fp = refs.PosExpr(-7.13)
+
+    assert divmod(lhs, rhs)._get_value() == divmod(7, 13)
+    assert round(fp)._get_value() == round(-7.13)
+    assert math.trunc(fp)._get_value() == math.trunc(-7.13)
+    assert math.floor(fp)._get_value() == math.floor(-7.13)
+    assert math.ceil(fp)._get_value() == math.ceil(-7.13)
+    assert abs(fp)._get_value() == abs(-7.13)
+    # These will not work, as Python verifies the type of the result:
+    # assert complex(lhs, rhs)._get_value() == complex(7, 13)
+    # assert int(fp)._get_value() == int(-7.13)
+    # assert float(lhs)._get_value() == float(7)
+
+
+@pytest.mark.xfail(reason='Undefined behaviour')
+def test_ref_inplace_ops():
+    manager = tasks.Manager()
+    container = np.array([1, 2])
+    ref = manager.ref(container, 'ref')
+
+    assert np.all(ref._get_value() == [1, 2])
+    ref += 3
+    assert np.all(ref._get_value() == [4, 5])
+
+    # The below does not work, as it is not clear how to implement this in a way
+    # that is universal. Is it even desired?
+    assert np.all(container == [4, 5])
+
+
+def test_itemref():
+    manager = tasks.Manager()
+    container = {'a': 1, 'b': 2}
+    ref = manager.ref(container, 'ref')
+
+    item_ref_a = ref['a']
+    assert item_ref_a._get_value() == 1
+
+    item_ref_b = ref['b']
+    assert item_ref_b._get_value() == 2
+    item_ref_b._set_value(3)
+    assert item_ref_b._get_value() == 3
+
+
+def test_attrref():
+    class DummyClass:
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+    manager = tasks.Manager()
+    container = DummyClass(1, 2)
+    ref = manager.ref(container, 'ref')
+
+    attr_ref_a = ref.a
+    assert attr_ref_a._get_value() == 1
+
+    attr_ref_b = ref.b
+    assert attr_ref_b._get_value() == 2
+    attr_ref_b._set_value(3)
+    assert attr_ref_b._get_value() == 3
+
+
+def test_call_ref():
+    def func(arg1, arg2, *, kwarg1, kwarg2):
+        return arg1, arg2, kwarg1, kwarg2
+
+    manager = tasks.Manager()
+    container = {'arg1': 1, 'kwarg1': 3}
+    data_ref = manager.ref(container, 'container')
+
+    manager = tasks.Manager()
+    ref = manager.ref(func, 'func')
+
+    call_ref = ref(data_ref['arg1'], 4, kwarg2=2, kwarg1=data_ref['kwarg1'])
+    assert call_ref._get_value() == (1, 4, 3, 2)
+
+    assert call_ref._get_dependencies() == {data_ref['arg1'], data_ref['kwarg1']}
+
+
+def test_objectattrref():
+    container = {'a': 3}
+    manager = tasks.Manager()
+    ref = manager.refattr(container, 'ref')
+
+    assert ref.a._get_value() == 3
+
+    ref.b = 42
+    assert ref.b._get_value() == 42
+    assert container['b'] == 42
+
+
+def test_refcount():
+    ref_count = refs.RefCount()
+    ref_count.extend(['a', 'b'])
+    ref_count.append('b')
+
+    assert ref_count['a'] == 1
+    assert ref_count['b'] == 2
+
+    ref_count.append('b')
+    assert ref_count['a'] == 1
+    assert ref_count['b'] == 3
+
+    ref_count.remove('a')
+    assert 'a' not in ref_count
+    assert ref_count['b'] == 3
+
+    ref_count.remove('b')
+    assert 'a' not in ref_count
+    assert ref_count['b'] == 2
+
+
+def test_cythonized():
+    assert refs.is_cythonized()

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -68,9 +68,9 @@ def test_binary_expressions():
     assert ((lhs + rhs) == (lhs + refs.PosExpr(13))) is True  # equal even if ids differ
     assert ((lhs + rhs) != (lhs + 13)) is True  # unequal, as type(rhs) != type(13)
     # Actual deferred equality check:
-    assert (lhs + rhs).deferred_equal(lhs + refs.PosExpr(13))._get_value() is True
-    assert (lhs + rhs).deferred_equal(lhs + 13)._get_value() is True
-    assert (lhs + rhs).deferred_equal(lhs)._get_value() is False
+    assert (lhs + rhs).eq(lhs + refs.PosExpr(13))._get_value() is True
+    assert (lhs + rhs).eq(lhs + 13)._get_value() is True
+    assert (lhs + rhs).eq(lhs)._get_value() is False
 
 
 def test_matmul_expression():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,362 @@
+import numpy as np
+import pytest
+
+import xdeps as xd
+import xdeps.tasks
+
+
+def test_manager_refs():
+    manager = xd.Manager()
+    container1 = {'b': 3}
+    container2 = {}
+    ref1 = manager.ref(container1, 'ref1')
+    ref2 = manager.ref(container2, 'ref2')
+
+    ref1['a'] = 1
+    ref2['a'] = 2
+
+    assert container1['a'] == 1
+    assert ref1['a']._get_value() == 1
+    assert container2['a'] == 2
+    assert ref2['a']._get_value() == 2
+
+    assert container1['b'] == 3
+    assert ref1['b']._get_value() == 3
+
+
+def test_expr_task():
+    manager = xd.Manager()
+    container = {'b': 3, 'c': 4}
+    ref = manager.ref(container, 'ref')
+    target = ref['a']
+    expr = 2 * ref['b'] + 3 * ref['c']
+
+    expr_task = xdeps.tasks.ExprTask(target, expr)
+
+    assert expr_task.expr == expr
+    assert expr_task.taskid == target
+    assert expr_task.dependencies == {ref['b'], ref['c']}
+    assert expr_task.targets == {target}
+
+    assert container == {'b': 3, 'c': 4}
+    expr_task.run()
+    assert container == {'a': 18, 'b': 3, 'c': 4}
+
+
+def test_depenv():
+    manager = xd.Manager()
+    container = {'b': 3, 'c': 4}
+    ref = manager.ref(container, 'ref')
+    ref['a'] = ref['b'] + ref['c']
+
+    depenv = xd.tasks.DepEnv(container, ref)
+
+    assert (depenv['b'] == 3) is True
+    assert (depenv['c'] == 4) is True
+    assert (depenv['a'] == 7) is True
+    assert set(depenv.keys()) == {'a', 'b', 'c'}
+
+    depenv['b'] = 5
+    depenv.c = 6
+    assert (depenv['a'] == 11) is True
+
+    assert (depenv._eval('a + b')._value == 16) is True
+
+
+@pytest.fixture(scope='function')
+def example_manager():
+    manager = xd.Manager()
+
+    container1 = {'a': 12, 'b': 8, 'c': -4, 'g': 42}
+    ref1 = manager.ref(container1, 'ref1')
+
+    container2 = {'d': [2, 3]}
+    ref2 = manager.ref(container2, 'ref2')
+
+    # We are realising the following setup in the test:
+    #
+    #            ╭ [a]─┐                                      Legend:
+    #            │     │                                      [x] ref/expr x
+    # container1 │ [b]─┴─►(f=a+b)─►[f]─┐                      (x) task x
+    #            │                     │
+    #            ╰ [c]───►(g=-c)─►[g]──┴─►(h=√(f-g))─►[h]─┐
+    #                                                     │
+    #                                                     │
+    #            ╭ [d[0]]─┐                               │
+    # container2 │        │                               │
+    #            ╰ [d[1]]─┴───►(e[0]=d[0]+d[1])───►[e[0]]─┴─►(j=h+e[0])─►[j]
+
+    ref1['f'] = ref1['a'] + ref1['b']
+
+    ref1['h'] = (ref1['f'] - ref1['g']) ** 0.5
+
+    # Define [g] after use to test to fully test manager.register with rtasks.
+    ref1['g'] = -ref1['c']
+
+    ref2['e'] = [None]
+    ref2['e'][0] = ref2['d'][0] * ref2['d'][1]
+
+    ref2['j'] = ref1['h'] + ref2['e'][0]
+
+    return manager, [ref1, ref2], [container1, container2]
+
+
+def test_manager(example_manager):
+    manager, refs, containers = example_manager
+    ref1, ref2 = refs
+    container1, container2 = containers
+
+    # First we check that everything was registered correctly
+    f_expr = ref1['a'] + ref1['b']
+    h_expr = (ref1['f'] - ref1['g']) ** 0.5
+    g_expr = -ref1['c']
+    e0_expr = ref2['d'][0] * ref2['d'][1]
+    j_expr = ref1['h'] + ref2['e'][0]
+
+    # Check that tasks are correctly created.
+    assert len(manager.tasks) == 5
+    assert manager.tasks[ref1['f']].expr.equals(f_expr)
+    assert manager.tasks[ref1['g']].expr.equals(g_expr)
+    assert manager.tasks[ref1['h']].expr.equals(h_expr)
+    assert manager.tasks[ref2['e'][0]].expr.equals(e0_expr)
+    assert manager.tasks[ref2['j']].expr.equals(j_expr)
+
+    # Check that rdeps are correctly created.
+    assert len(manager.rdeps) == 11
+    assert set(manager.rdeps[ref1['a']]) == {ref1['f']}  # [f] depends on [a]
+    assert set(manager.rdeps[ref1['b']]) == {ref1['f']}  # [f] depends on [b]
+    assert set(manager.rdeps[ref1['c']]) == {ref1['g']}  # [g] depends on [c]
+    assert set(manager.rdeps[ref1['f']]) == {ref1['h']}  # [h] depends on [f]
+    assert set(manager.rdeps[ref1['g']]) == {ref1['h']}  # [h] depends on [g]
+    # [e[0]] and thus [e] depend on [d[0]], [d[1]], and thus [d]:
+    assert set(manager.rdeps[ref2['d']]) == {ref2['e'], ref2['e'][0]}
+    assert set(manager.rdeps[ref2['d'][0]]) == {ref2['e'], ref2['e'][0]}
+    assert set(manager.rdeps[ref2['d'][1]]) == {ref2['e'], ref2['e'][0]}
+    assert set(manager.rdeps[ref1['h']]) == {ref2['j']}  # [j] depends on [h]
+    assert set(manager.rdeps[ref2['e'][0]]) == {ref2['j']}  # [j] depends on [e[0]]
+    assert set(manager.rdeps[ref2['e']]) == {ref2['j']}  # thus [j] depends on [e]
+
+    # Check that rtasks are correctly created.
+    # This is a special case as all tasks so far output one ref.
+    # In this case is subset of rdeps as it has taskids on the lhs (and since
+    # not all refs are tasks, we have fewer entries than in rdeps).
+    assert len(manager.rtasks) == 4
+    assert set(manager.rtasks[ref1['h']]) == {ref2['j']}
+    assert set(manager.rtasks[ref2['e'][0]]) == {ref2['j']}
+    assert set(manager.rtasks[ref1['f']]) == {ref1['h']}
+    assert set(manager.rtasks[ref1['g']]) == {ref1['h']}
+
+    # Check that deptasks are correctly created.
+    # Almost the same as rdeps but maps to taskids instead of refs, so:
+    # - We have an entry for [j],
+    # - [e[0]] etc. are on the rhs but not [e].
+    assert len(manager.deptasks) == 12
+    assert set(manager.deptasks[ref1['a']]) == {ref1['f']}
+    assert set(manager.deptasks[ref1['b']]) == {ref1['f']}
+    assert set(manager.deptasks[ref1['c']]) == {ref1['g']}
+    assert set(manager.deptasks[ref1['f']]) == {ref1['h']}
+    assert set(manager.deptasks[ref1['g']]) == {ref1['h']}
+    assert set(manager.deptasks[ref2['d']]) == {ref2['e'][0]}
+    assert set(manager.deptasks[ref2['d'][0]]) == {ref2['e'][0]}
+    assert set(manager.deptasks[ref2['d'][1]]) == {ref2['e'][0]}
+    assert set(manager.deptasks[ref1['h']]) == {ref2['j']}
+    assert set(manager.deptasks[ref2['e'][0]]) == {ref2['j']}
+    assert set(manager.deptasks[ref2['e']]) == {ref2['j']}
+    assert set(manager.deptasks[ref2['j']]) == set()
+
+    # Check that tartasks are correctly created.
+    # In this case it is (roughly) an identity on refs that are tasks,
+    # and zero otherwise.
+    assert len(manager.tartasks) == 12
+    # Tasks:
+    for ref in [ref1['f'], ref1['g'], ref1['h'], ref2['e'][0], ref2['j']]:
+        assert set(manager.tartasks[ref]) == {ref}
+    # Extra considerations for e for e[0] etc.:
+    assert set(manager.tartasks[ref2['e']]) == {ref2['e'][0]}
+    # Refs that aren't tasks:
+    for ref in [ref1['a'], ref1['b'], ref1['c'], ref2['d'], ref2['d'][0], ref2['d'][1]]:
+        assert set(manager.tartasks[ref]) == set()
+
+    # Check that containers are correctly created.
+    assert manager.containers == {'ref1': ref1, 'ref2': ref2}
+
+    # Now we check that the manager can correctly execute the tasks
+    assert container1['f'] == 20
+    assert container1['g'] == 4
+    assert container1['h'] == 4
+    assert container2['e'][0] == 6
+    assert container2['j'] == 10
+
+    # Test that values are updated correctly
+    ref1['a'] = 21
+    assert container2['j'] == 11
+
+
+def test_manager_unregister(example_manager):
+    manager, refs, containers = example_manager
+    ref1, ref2 = refs
+    container1, container2 = containers
+
+    # Test unregistering a task
+    ref1['h'] = 4
+    assert container2['j'] == 10
+
+
+def test_manager_clone_verify_refresh(example_manager):
+    manager, refs, _ = example_manager
+    ref1, ref2 = refs
+
+    # Test consistency and make a copy
+    manager.verify()
+    manager_copy = manager.copy()
+
+    # Mess up consistency and check again
+    manager.rtasks[ref1['f']].append(ref2['e'][0])
+    manager.rdeps[ref1['b']].remove(ref1['f'])
+
+    with pytest.raises(ValueError) as error:
+        manager.verify()
+    assert 'not consistent' in str(error.value)
+
+    manager_copy.verify()  # the copy should still be okay
+
+    # Refresh and check again
+    manager.refresh()
+    manager.verify()
+
+
+def test_manager_dump_and_load(example_manager):
+    manager, _, _ = example_manager
+
+    dumped = manager.dump()
+
+    new_manager = xd.Manager()
+    new_container1 = {'a': 10, 'b': 10, 'c': -4}
+    new_ref1 = new_manager.ref(new_container1, 'new_ref1')
+    new_container2 = {'d': [3, 2], 'e': [-99]}
+    new_ref2 = new_manager.ref(new_container2, 'new_ref2')
+
+    old_expr = new_ref2['j'] = 2 * new_ref1['a']  # this will be removed by load
+
+    new_containers = {
+        'ref1': new_ref1,
+        'ref2': new_ref2,
+    }
+    new_manager.load(dumped, new_containers)
+
+    assert new_containers['ref2']['j'] == 10
+    assert not new_manager.tasks[new_ref2['j']].expr.equals(old_expr)
+
+
+def test_ref_count():
+    manager = xd.Manager()
+    container = {'a': 3, 'b': [None], 'c': None}
+    ref = manager.ref(container, 'ref')
+
+    ref['c'] = ref['b'][0]
+    ref['b'][0] = ref['a']
+
+    assert len(manager.rtasks) == 1
+    assert len(manager.rtasks[ref['b'][0]]) == 1
+    assert manager.rtasks[ref['b'][0]][ref['c']] == 2
+    # This is a bit weird, the task (b[0]) influences [c] twice.
+    # One time directly, and the other comes from the fact that the task
+    # (b[0]) influences both the ref [b[0]] and [b]. Therefore both of these
+    # refs, in turn, influence [c].
+    # The setup of this example requires [a], as we need two tasks, the first
+    # one being (b[0]) and the second one being (a).
+
+    assert container == {'a': 3, 'b': [3], 'c': 3}
+
+
+def test_function_task():
+    manager = xd.Manager()
+    container = {'a': 3, 'b': 4}
+    ref = manager.ref(container, 'ref')
+
+    def action():
+        ref['c'] = ref['a']._get_value() + ref['b']._get_value()
+        ref['d'] = ref['a']._get_value() * ref['b']._get_value()
+
+    task = xd.tasks.FunctionTask(
+        taskid='my_action',
+        action=action,
+        targets={ref['c'], ref['d']},
+        dependencies={ref['a'], ref['b']},
+    )
+
+    manager.register(task)
+    task.run()
+
+    assert container == {'a': 3, 'b': 4, 'c': 7, 'd': 12}
+
+    ref['a'] = 4
+    assert container == {'a': 4, 'b': 4, 'c': 8, 'd': 16}
+
+    assert len(manager.tasks) == 1
+    assert manager.tasks['my_action'] is task
+
+    assert len(manager.rdeps) == 2
+    assert set(manager.rdeps[ref['a']]) == {ref['c'], ref['d']}
+    assert set(manager.rdeps[ref['b']]) == {ref['c'], ref['d']}
+
+    assert len(manager.deptasks) == 4
+    assert set(manager.deptasks[ref['a']]) == {'my_action'}
+    assert set(manager.deptasks[ref['b']]) == {'my_action'}
+    assert set(manager.deptasks[ref['c']]) == set()
+    assert set(manager.deptasks[ref['d']]) == set()
+
+    assert len(manager.tartasks) == 4
+    assert set(manager.tartasks[ref['a']]) == set()
+    assert set(manager.tartasks[ref['b']]) == set()
+    assert set(manager.tartasks[ref['c']]) == {'my_action'}
+    assert set(manager.tartasks[ref['d']]) == {'my_action'}
+
+
+@pytest.mark.xfail(reason='Not implemented yet, unclear if it should be')
+def test_function_task_depends_on_container():
+    manager = xd.Manager()
+    container_source = {'a': 3, 'b': 4}
+    container_target = {}
+    ref_source = manager.ref(container_source, 'ref_source')
+    ref_target = manager.ref(container_target, 'ref_target')
+
+    def action():
+        ref_target['c'] = ref_source['a']._get_value() + ref_source['b']._get_value()
+        ref_target['d'] = ref_source['a']._get_value() * ref_source['b']._get_value()
+
+    task = xd.tasks.FunctionTask(
+        taskid='my_action',
+        action=action,
+        targets={ref_target['c'], ref_target['d']},
+        dependencies={ref_source},
+    )
+
+    manager.register(task)
+    task.run()
+
+    assert container_target == {'c': 7, 'd': 12}
+    ref_source['a'] = 4
+    assert container_target == {'c': 8, 'd': 16}
+
+
+def test_lsa_knob_example():
+    manager = xd.Manager()
+    container = {'src': 10, 'tar': list(range(5))}
+    ref = manager.ref(container, 'ref')
+
+    weights = np.linspace(0, 1, 5)
+    lsa = xd.tasks.LinearKnob(
+        taskid='lsa',
+        source=ref['src'],
+        weights=weights,
+        targets=[ref['tar'][ii] for ii in range(5)],
+    )
+
+    manager.register(lsa)
+    lsa.run()
+
+    assert container['tar'] == [0, 1, 2, 3, 4]
+
+    ref['src'] = 20
+    assert container['tar'] == [0.0, 3.5, 7.0, 10.5, 14.0]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -244,8 +244,8 @@ def test_manager_dump_and_load(example_manager):
     }
     new_manager.load(dumped, new_containers)
 
-    assert new_containers['ref2']['j'] == 10
-    assert not new_manager.tasks[new_ref2['j']].expr.equals(old_expr)
+    assert new_containers['ref2']['j']._get_value() == 20
+    assert not new_manager.tasks[new_ref2['j']].expr == old_expr
 
 
 def test_ref_count():

--- a/tests/test_xdeps.py
+++ b/tests/test_xdeps.py
@@ -4,6 +4,7 @@
 # ######################################### #
 
 import xdeps
+from xdeps.tasks import AttrDict
 
 
 def test_set():
@@ -94,3 +95,22 @@ def test_unregister():
 
     assert container['c']['x'] == 4
     assert container['c']['y'] == 12  # unchanged
+
+
+def test_collisions():
+    num_elements = 100000
+
+    mgr = xdeps.Manager()
+
+    elements = {f'bend{ii}': AttrDict(k1=0) for ii in range(num_elements)}
+    element_refs = mgr.ref(elements, 'element_refs')
+
+    vars = {}
+    var_refs = mgr.ref(vars, 'var_refs')
+
+    for ii in range(num_elements):
+        var_refs[f'k{ii}'] = 1
+        element_refs[f'bend{ii}'].k0 = var_refs[f'k{ii}']
+        assert len(mgr.tasks) == ii + 1
+
+    assert len(mgr.tasks) == num_elements

--- a/xdeps/generate_refs.py
+++ b/xdeps/generate_refs.py
@@ -16,7 +16,6 @@ BINARY_OPS = {
     operator.xor: "^",
     operator.lt: "<",
     operator.le: "<=",
-    operator.eq: "==",
     operator.ne: "!=",
     operator.ge: ">=",
     operator.gt: ">",

--- a/xdeps/generate_refs.py
+++ b/xdeps/generate_refs.py
@@ -1,0 +1,82 @@
+import builtins
+import math
+import operator
+
+BINARY_OPS = {
+    operator.add: "+",
+    operator.sub: "-",
+    operator.mul: "*",
+    operator.matmul: "@",
+    operator.truediv: "/",
+    operator.floordiv: "//",
+    operator.mod: "%",
+    operator.pow: "**",
+    operator.and_: "&",
+    operator.or_: "|",
+    operator.xor: "^",
+    operator.lt: "<",
+    operator.le: "<=",
+    operator.eq: "==",
+    operator.ne: "!=",
+    operator.ge: ">=",
+    operator.gt: ">",
+    operator.rshift: ">>",
+    operator.lshift: "<<",
+}
+
+UNARY_OPS = {
+    operator.neg: "-",
+    operator.pos: "+",
+    operator.invert: "~",
+}
+
+GUARD_ZERO_DIVISION = ['__truediv__', '__floordiv__', '__mod__']
+
+
+def generate_binary_refs():
+    for op, op_str in BINARY_OPS.items():
+        op_name = op.__name__
+        if op_name == 'and_':
+            op_name = 'BitwiseAnd'
+        elif op_name == 'or_':
+            op_name = 'BitwiseOr'
+        else:
+            op_name = op_name.title()
+        print(f"""\
+@cython.cclass
+class {op_name}Expr(BinOpExpr):
+    _op_str = '{op_str}'
+
+    def _get_value(self):
+        lhs = ARef._mk_value(self._lhs)
+        rhs = ARef._mk_value(self._rhs)
+""")
+        if op_name not in GUARD_ZERO_DIVISION:
+            print(f"""\
+        return lhs {op_str} rhs
+""")
+        else:
+            print(f"""\
+        try:
+            return lhs {op_str} rhs
+        except ZeroDivisionError:
+            return float('nan')
+""")
+
+
+def generate_unary_refs():
+    for op, op_str in UNARY_OPS.items():
+        print(f"""\
+@cython.cclass
+class {op.__name__.title()}Expr(UnaryOpExpr):
+    _op_str = '{op_str}'
+    
+    def _get_value(self):
+        arg = ARef._mk_value(self._arg)
+        return {op_str}arg
+        
+""")
+
+
+generate_binary_refs()
+generate_unary_refs()

--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -118,9 +118,21 @@ class BaseRef:
         return self._hash
 
     def __eq__(self, other):
+        """Check equality of the expressions `self` and `other`.
+
+        Check if `self` and `other` are the same. Crucially, even if self._value
+        and other._value are the same, this does not necessarily imply that
+        self == other. Python requires that if a == b then hash(a) == hash(b).
+        Since in our case two different ref objects may have the same hash (by
+        virtue of representing the same expression!), we must not use __eq__ to
+        create expressions.
+
+        If a deferred equality expression is desired, use `self.eq`.
+        """
         return str(self) == str(other)
 
-    def deferred_equal(self, other):
+    def eq(self, other):
+        """Deferred expression for the equality of values of `self` and `other`."""
         return EqExpr(self, other)
 
     @staticmethod

--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -117,8 +117,11 @@ class BaseRef:
     def __hash__(self):
         return self._hash
 
-    def equals(self, other):
-        return hash(self) == hash(other)
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+    def deferred_equal(self, other):
+        return EqExpr(self, other)
 
     @staticmethod
     def _mk_value(value):
@@ -238,18 +241,6 @@ class BaseRef:
 
     def __rle__(self, other):
         return LeExpr(other)
-
-    def __eq__(self, other):
-        return EqExpr(self, other)
-
-    def __req__(self, other):
-        return EqExpr(other, self)
-
-    def __ne__(self, other):
-        return NeExpr(self, other)
-
-    def __rne__(self, other):
-        return NeExpr(other, self)
 
     def __ge__(self, other):
         return GeExpr(self, other)

--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -131,11 +131,11 @@ class BaseRef:
         """
         return str(self) == str(other)
 
-    def eq(self, other):
+    def _eq(self, other):
         """Deferred expression for the equality of values of `self` and `other`."""
         return EqExpr(self, other)
 
-    def neq(self, other):
+    def _neq(self, other):
         """Deferred expression for the inequality of values of `self` and `other`."""
         return NeExpr(self, other)
 

--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -135,6 +135,10 @@ class BaseRef:
         """Deferred expression for the equality of values of `self` and `other`."""
         return EqExpr(self, other)
 
+    def neq(self, other):
+        """Deferred expression for the inequality of values of `self` and `other`."""
+        return NeExpr(self, other)
+
     @staticmethod
     def _mk_value(value):
         if isinstance(value, BaseRef):

--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -127,7 +127,7 @@ class BaseRef:
         virtue of representing the same expression!), we must not use __eq__ to
         create expressions.
 
-        If a deferred equality expression is desired, use `self.eq`.
+        If a deferred equality expression is desired, use `self._eq`.
         """
         return str(self) == str(other)
 

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -1,6 +1,8 @@
 import os
 import pathlib
 import re
+from typing import Collection
+
 import numpy as np
 
 gblmath = {"np": np}
@@ -40,6 +42,17 @@ def _to_str(arr, digits, fixed="g", max_len=None):
         # each element.
         fmt = "%%.%d%s" % (digits, fixed)
         out = np.char.mod(fmt, arr)
+    elif arr.dtype.kind == "O" and isinstance(arr[0], Collection):
+        # If array of collections (array with dtype=object) or list, give shape
+        lengths = []
+        for entry in arr:
+            if isinstance(entry, np.ndarray):
+                lengths.append(f'<array of shape {entry.shape}>')
+            elif isinstance(entry, Collection):
+                lengths.append(f'<collection of length {len(entry)}>')
+            else:
+                lengths.append(str(entry))
+        out = np.array(lengths)
     else:
         # Any other flat array: stringify.
         out = arr.astype(f'U')

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -206,7 +206,7 @@ class Table:
     ):
         self._data = data
 
-        self._col_names = list(data.keys()) if col_names is None else col_names
+        self._col_names = list(data.keys() if col_names is None else col_names)
         for kk in self._col_names:
             vv = data[kk]
             if not hasattr(vv, 'dtype'):

--- a/xdeps/tasks.py
+++ b/xdeps/tasks.py
@@ -9,7 +9,7 @@ import logging
 from copy import deepcopy
 
 from .refs import ARef, CallRef, Ref, ObjectAttrRef, RefCount
-from .utils import os_display_png, mpl_display_png, ipy_display_png
+from .utils import plot_pdot
 from .utils import AttrDict
 from .sorting import toposort
 
@@ -303,13 +303,15 @@ class Manager:
         exec(fdef, gbl, lcl)
         return lcl[name]
 
-    def plot_deps(self, start=None, backend="ipy"):
+    def plot_deps(self, start=None, **kwargs):
         """Plot a graph of task and target dependencies from start.
 
         Possible backend:
             mpl: generate a figure in matplotlib
             os: generate a file /tmp/out.png and use `display` to show it
             ipy: use Ipython facility for Jupyter notebooks
+
+        ftype: png, svg, or pdf
         """
         from pydot import Dot, Node, Edge
 
@@ -320,27 +322,24 @@ class Manager:
             tn = Node(" " + str(task.taskid), shape="circle")
             pdot.add_node(tn)
             for tt in task.targets:
-                pdot.add_node(Node(str(tt), shape="square"))
+                pdot.add_node(Node(str(tt), shape="box"))
                 pdot.add_edge(Edge(tn, str(tt), color="blue"))
             for tt in task.dependencies:
-                pdot.add_node(Node(str(tt), shape="square"))
+                pdot.add_node(Node(str(tt), shape="box"))
                 pdot.add_edge(Edge(str(tt), tn, color="blue"))
-        png = pdot.create_png()
-        if backend == "mpl":
-            mpl_display_png(png)
-        elif backend == "os":
-            os_display_png(png)
-        elif backend == "ipy":
-            ipy_display_png(png)
+
+        plot_pdot(pdot, **kwargs)
         return pdot
 
-    def plot_tasks(self, start=None, backend="ipy"):
+    def plot_tasks(self, start=None, **kwargs):
         """Plot a graph of task dependencies
 
         Possible backend:
             mpl: generate a figure in matplotlib
             os: generate a file /tmp/out.png and use `display` to show it
             ipy: use Ipython facility for Jupyter notebooks
+
+        ftype: png, svg, or pdf
         """
         from pydot import Dot, Node, Edge
 
@@ -353,13 +352,8 @@ class Manager:
             for dep in task.dependencies:
                 for tt in self.tartasks[dep]:
                     pdot.add_edge(Edge(str(tt), tn, color="blue"))
-        png = pdot.create_png()
-        if backend == "mpl":
-            mpl_display_png(png)
-        elif backend == "os":
-            os_display_png(png)
-        elif backend == "ipy":
-            ipy_display_png(png)
+
+        plot_pdot(pdot, **kwargs)
         return pdot
 
     def dump(self):

--- a/xdeps/utils.py
+++ b/xdeps/utils.py
@@ -2,15 +2,16 @@
 # This file is part of the Xdeps Package.   #
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
+from typing import Literal
 
 
-def mpl_display_png(png):
+def mpl_display_image(image_data):
     import io
     import matplotlib.pyplot as plt
     import matplotlib.image as mpimg
 
     sio = io.BytesIO()
-    sio.write(png)
+    sio.write(image_data)
     sio.seek(0)
     img = mpimg.imread(sio)
     imgplot = plt.imshow(img, aspect="auto")
@@ -19,19 +20,57 @@ def mpl_display_png(png):
     plt.yticks([])
 
 
-def os_display_png(png):
+def os_display_image(image_data, ftype="png", remove_file=True):
     import os
+    from sys import platform
 
-    with open("/tmp/out.png", "wb") as fh:
-        fh.write(png)
-    os.system("(display /tmp/out.png && rm /tmp/out.png)&")
+    fname = f"/tmp/out.{ftype}"
+    with open(fname, "wb") as fh:
+        fh.write(image_data)
+
+    if platform == "darwin":
+        # open doesn't block, wait a little not to remove the file too early
+        os.system(f"open {fname} && sleep 5")
+    else:
+        os.system(f"display {fname}&")
+
+    if remove_file:
+        os.remove(fname)
 
 
-def ipy_display_png(png):
+def ipy_display_image(image_data):
     from IPython.display import Image, display
 
-    plt = Image(png)
+    plt = Image(image_data)
     display(plt)
+
+
+def plot_pdot(
+        pdot,
+        backend: Literal['mpl', 'os', 'ipy'] = 'ipy',
+        ftype: Literal['png', 'svg', 'pdf'] = 'png',
+        remove_file: bool = True,
+):
+    if ftype == "png":
+        image_data = pdot.create_png()
+    elif ftype == "svg":
+        image_data = pdot.create_svg()
+    elif ftype == "pdf":
+        image_data = pdot.create_pdf()
+    else:
+        raise ValueError(f"Unknown ftype: {ftype}")
+
+    if backend == "mpl" and ftype == "png":
+        mpl_display_image(image_data)
+    elif backend == "os":
+        os_display_image(image_data, ftype=ftype, remove_file=remove_file)
+    elif backend == "ipy":
+        ipy_display_image(image_data)
+    else:
+        raise ValueError(f"Unknown backend: {backend} or combination of "
+                         f"ftype ({ftype}) and backend invalid.")
+
+    return pdot
 
 
 class AttrDict(dict):

--- a/xdeps/utils.py
+++ b/xdeps/utils.py
@@ -28,14 +28,16 @@ def os_display_image(image_data, ftype="png", remove_file=True):
     with open(fname, "wb") as fh:
         fh.write(image_data)
 
+    if remove_file:
+        remove_cmd = f"rm {fname}"
+    else:
+        remove_cmd = "true"
+
     if platform == "darwin":
         # open doesn't block, wait a little not to remove the file too early
-        os.system(f"open {fname} && sleep 5")
+        os.system(f"(open {fname} && sleep 5 && {remove_cmd})&")
     else:
-        os.system(f"display {fname}&")
-
-    if remove_file:
-        os.remove(fname)
+        os.system(f"(display {fname} && {remove_cmd})&")
 
 
 def ipy_display_image(image_data):


### PR DESCRIPTION
**Changes:**

- Cythonize `refs.py` to gain performance (#39).
- Print only shapes of arrays in the table, and by default put their columns at the end (#45).
- Fix plotting example and add more options for plotting (#36 and #40 included in #39)
- Fix minor bugs relating to ensuring list type for `_col_names` in table (#33 and #38).
- Refactoring of unused code (#37 included in #39)