### PR TITLE
Improve pickling the manager in Cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,10 @@
 *.swp
 *.egg-info
 .DS_Store
-
+*.so
+.pymon
+.ipynb_checkpoints
+**/.coverage
+**/.coverage.*
+**/checkpoint_restart.dat
+build/

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,4 +1,9 @@
+# copyright ############################### #
+# This file is part of the Xdeps Package.   #
+# Copyright (c) CERN, 2023.                 #
+# ######################################### #
 import numpy as np
+import pickle
 import pytest
 
 import xdeps as xd
@@ -84,7 +89,7 @@ def example_manager():
     #                                                     │
     #            ╭ [d[0]]─┐                               │
     # container2 │        │                               │
-    #            ╰ [d[1]]─┴───►(e[0]=d[0]+d[1])───►[e[0]]─┴─►(j=h+e[0])─►[j]
+    #            ╰ [d[1]]─┴───►(e[0]=d[0]*d[1])───►[e[0]]─┴─►(j=h+e[0])─►[j]
 
     ref1['f'] = ref1['a'] + ref1['b']
 
@@ -246,6 +251,29 @@ def test_manager_dump_and_load(example_manager):
 
     assert new_containers['ref2']['j']._get_value() == 20
     assert not new_manager.tasks[new_ref2['j']].expr == old_expr
+
+
+def test_manager_pickle(example_manager):
+    manager, _, original_containers = example_manager
+    original1, original2 = original_containers
+
+    pickled = pickle.dumps(manager)
+    new_manager = pickle.loads(pickled)
+
+    ref1 = new_manager.containers['ref1']
+    container1 = ref1._owner
+    ref2 = new_manager.containers['ref2']
+    container2 = ref2._owner
+
+    ref1['a'] = 32
+    ref2['d'][1] = 5
+
+    assert container1 is not original1
+    assert container2 is not original2
+    assert container1['f'] == 40
+    assert container1['h'] == 6
+    assert container2['e'][0] == 10
+    assert container2['j'] == 16
 
 
 def test_ref_count():

--- a/tests/test_xdeps.py
+++ b/tests/test_xdeps.py
@@ -2,6 +2,7 @@
 # This file is part of the Xdeps Package.   #
 # Copyright (c) CERN, 2021.                 #
 # ######################################### #
+import pickle
 
 import xdeps
 from xdeps.tasks import AttrDict

--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -107,8 +107,8 @@ class BaseRef:
         removed, and no workaround is provided until an explicit need for these
         methods arises.
     """
-    _manager = cython.declare(object, visibility='public', value=None)
-    _hash = cython.declare(int, visibility='private')
+    _manager = cython.declare(object, visibility='readonly', value=None)
+    _hash = cython.declare(int, visibility='readonly')
 
     def __init__(self, *args, **kwargs):
         # To keep compatibility with pure Python (useful for debugging simpler
@@ -314,8 +314,8 @@ class MutableRef(BaseRef):
     """
     An (abstract) class representing a reference to a mutable object.
     """
-    _owner = cython.declare(object, visibility='public', value=None)
-    _key = cython.declare(object, visibility='public', value=None)
+    _owner = cython.declare(object, visibility='readonly', value=None)
+    _key = cython.declare(object, visibility='readonly', value=None)
 
     def __cinit__(self, _owner, _key, _manager):
         self._owner = _owner
@@ -615,8 +615,8 @@ class BinOpExpr(BaseRef):
     2. A property `_op_str` which returns the string representation of the
        operator for pretty printing.
     """
-    _lhs = cython.declare(object, visibility='public')
-    _rhs = cython.declare(object, visibility='public')
+    _lhs = cython.declare(object, visibility='readonly')
+    _rhs = cython.declare(object, visibility='readonly')
 
     def __cinit__(self, lhs, rhs):
         self._lhs = lhs
@@ -657,7 +657,7 @@ class UnaryOpExpr(BaseRef):
     2. A cython property `_op_str` which returns the string representation of
        the operator for pretty printing.
     """
-    _arg = cython.declare(object, visibility='public')
+    _arg = cython.declare(object, visibility='readonly')
 
     def __cinit__(self, arg):
         self._arg = arg
@@ -910,9 +910,9 @@ class InvertExpr(UnaryOpExpr):
 
 @cython.cclass
 class BuiltinRef(BaseRef):
-    _arg = cython.declare(object, visibility='public')
-    _op = cython.declare(object, visibility='public')
-    _params = cython.declare(tuple, visibility='public')
+    _arg = cython.declare(object, visibility='readonly')
+    _op = cython.declare(object, visibility='readonly')
+    _params = cython.declare(tuple, visibility='readonly')
 
     def __cinit__(self, arg, op, params=()):
         self._arg = arg
@@ -946,9 +946,9 @@ class BuiltinRef(BaseRef):
 
 @cython.cclass
 class CallRef(BaseRef):
-    _func = cython.declare(object, visibility='public')
-    _args = cython.declare(tuple, visibility='public')
-    _kwargs = cython.declare(tuple, visibility='public')
+    _func = cython.declare(object, visibility='readonly')
+    _args = cython.declare(tuple, visibility='readonly')
+    _kwargs = cython.declare(tuple, visibility='readonly')
 
     def __cinit__(self, func, args, kwargs):
         self._func = func


### PR DESCRIPTION
## Description

Provide a (potential) fix for the issue that transpired here: https://github.com/xsuite/xsuite/actions/runs/7078114510/job/19263287990.

When unpickling, pickle first creates the object with `__new__`, after which is populates the fields using `__getstate__`, `__reduce__`, or a built-in equivalent of these. While the issue is not reproducible, the hypothesis is that while pickling (note that a similar situation can theoretically happen when copying), the state of the object is invalid between the call to `__new__` and the fields population. This leads to either an invalid state of the hash (None), or in the case of hash collision (hash currently loaded from file) the string comparison of the refs can fail due to the fact that string returned is `None` (in particular in the case of `xdeps.refs.Ref.__repr__`).

Assuming these potential issues, this PR fixes them by:

- Implementing a `__cinit__` which in principle is called by Cython on object creation (together with `__new__`), which should prevent the object existing with an invalid state
- Not pickling the hash, which makes little sense, considering the hash function is randomly seeded in each interpreter, so hashes of the 'same' objects are not the same between runs.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
