### PR TITLE
Deploy xdeps on a tag push not on a gh release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,9 @@
 name: Publish Xdeps to PyPI
 
 on:
-  release:
-    types: [released, edited]
+  push:
+    tags:
+      - v*
 
 jobs:
   build-wheels:


### PR DESCRIPTION
## Description

Change the release workflow to deploy xdeps to PyPI when a new `v*` tag is pushed. This is to homogenise it with xsuite.