### PR TITLE
Sequence parser

### DIFF
--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -96,7 +96,7 @@ def is_cythonized():
 
 
 @cython.cclass
-class XMadFormatter:
+class XldFormatter:
     """A class used to govern the display of refs and expressions."""
     scope = cython.declare('BaseRef', visibility='readonly')
 
@@ -195,7 +195,7 @@ class BaseRef:
         """
         return str(self) == str(other)
 
-    def _formatted(self, formatter: XMadFormatter):
+    def _formatted(self, formatter: XldFormatter):
         """Return a formatted string representation of the ref/expression."""
         return repr(self)
 

--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -217,6 +217,9 @@ class BaseRef:
     def _get_value(self):
         raise NotImplementedError
 
+    def _set_to_expr(self, expr):
+        self._manager.set_value(self, expr)
+
     @property
     def _value(self):
         try:

--- a/xdeps/tasks.py
+++ b/xdeps/tasks.py
@@ -222,7 +222,6 @@ class Manager:
         self.rtasks = defaultdict(RefCount)
         self.deptasks = defaultdict(RefCount)
         self.tartasks = defaultdict(RefCount)
-        self.structure = defaultdict(RefCount)
         self._tree_frozen = False
 
     def ref(self, container=None, label="_"):
@@ -284,10 +283,6 @@ class Manager:
                 # logger.info("T:%s modifies deps of T:%s",taskid,deptask)
                 self.rtasks[taskid].append(deptask)
 
-        while isinstance(taskid, MutableRef) and not isinstance(taskid, Ref):
-            self.structure[taskid._owner].append(taskid)
-            taskid = taskid._owner
-
     def unregister(self, taskid):
         """Unregister the task identified by taskid"""
         if self._tree_frozen:
@@ -307,8 +302,6 @@ class Manager:
             self.tartasks[tar].remove(taskid)
         if taskid in self.rtasks:
             del self.rtasks[taskid]
-        if isinstance(taskid, MutableRef):
-            self.structure[taskid._owner].remove(taskid)
         del self.tasks[taskid]
 
     def freeze_tree(self):

--- a/xdeps/tasks.py
+++ b/xdeps/tasks.py
@@ -222,7 +222,7 @@ class Manager:
         self.rtasks = defaultdict(RefCount)
         self.deptasks = defaultdict(RefCount)
         self.tartasks = defaultdict(RefCount)
-        self.structure = defaultdict(set)
+        self.structure = defaultdict(RefCount)
         self._tree_frozen = False
 
     def ref(self, container=None, label="_"):
@@ -285,7 +285,7 @@ class Manager:
                 self.rtasks[taskid].append(deptask)
 
         while isinstance(taskid, MutableRef) and not isinstance(taskid, Ref):
-            self.structure[taskid._owner].add(taskid)
+            self.structure[taskid._owner].append(taskid)
             taskid = taskid._owner
 
     def unregister(self, taskid):


### PR DESCRIPTION
## Description

Provide features required by xsuite/xtrack#515:

- Add a `BaseRef._formatted(formatter)` method that returns a string corresponding to a representation of a `Ref`/and `Expr` according to the `formatter`.
- Add a `_set_to_expr` method that can reset the expression calculating the value of said ref.
- Introduce a `LiteralExpr` to enable the possibility of wrapping scalars: this can allow us to preserve the tree of an expression in full.
- Add a `Manager.structure` field that maps a ref to the refs that structurally depend on it (array element to the array, attribute to the owner, etc.). This is needed for fast retrieval of expressions from their "parent" containers.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
