### PR TITLE
disabling __iter__ in refs

### DIFF
--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -30,6 +30,7 @@ special_methods = {
     '__array_finalize__',
     '__array__',
     '__array_priority__',
+    '__iter__',
     # _ipython_canary_method_should_not_exist_ is used by IPython to detect
     # if an object 'lies' about its attributes due to its __getattr__. We should
     # not try to intercept it.


### PR DESCRIPTION
## Description
`__iter__` does not really make sense for refs, and can clog an interpreter by doing

```
from xdeps import Manager
a=mgr.ref({},"a")
list(a)
```
Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
