### PR TITLE
fix table indices with ,

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -15,6 +15,7 @@ data = {
 
 t = Table(data)
 
+
 def test_table_initialization():
     # Valid initialization
     data = {"name": np.array(["a", "b", "c"]), "value": np.array([1, 2, 3])}
@@ -77,7 +78,7 @@ def test_table_getitem_col_row():
     assert t["betx", "ip2"] == data["betx"][1]
     assert t["betx", ("ip2", 0)] == data["betx"][1]
     assert t["betx", ("ip2", 1)] == data["betx"][2]
-    assert t["betx", ("ip2",-1)] == data["betx"][2]
+    assert t["betx", ("ip2", -1)] == data["betx"][2]
     assert t["betx", "ip2::0"] == data["betx"][1]
     assert t["betx", "ip2::1"] == data["betx"][2]
     assert t["betx", "ip2::-1"] == data["betx"][2]
@@ -106,16 +107,14 @@ def test_table_getitem_edge_cases():
     with pytest.raises(KeyError) as e:
         t[:]
         assert str(e).startswith("Invalid arguments")
-    
+
     with pytest.raises(KeyError) as e:
         t[()]
         assert str(e).startswith("Empty selection")
 
-    assert t[("betx", 1)] == t["betx",1]
+    assert t[("betx", 1)] == t["betx", 1]
 
     assert t[("betx",)][2] == t["betx"][2]
-
-    
 
 
 def test_table_numpy_string():
@@ -214,6 +213,7 @@ def test_table_concatenate():
     assert len(concatenated_table) == 6
     assert np.array_equal(concatenated_table["value"], np.array([1, 2, 3, 4, 5, 6]))
 
+
 def test_table_transpose():
     data = {"name": np.array(["a", "b", "c"]), "value": np.array([1, 2, 3])}
     table = Table(data)
@@ -244,17 +244,19 @@ def test_table_show():
 
 ## Table cols tests
 
+
 def test_cols():
     assert isinstance(t.cols["betx"], Table)
     assert t.cols["betx", "bety"].betx[0] == t.betx[0]
+
 
 def test_cols_iter():
     data = {
         "name": np.array(["a", "b", "c"]),
         "c1": np.array([1, 2, 3]),
         "c2": np.array([4, 5, 6]),
-        "s1":1,
-        "s2":2,
+        "s1": 1,
+        "s2": 2,
     }
     with pytest.raises(ValueError) as err:
         Table(data)
@@ -267,8 +269,10 @@ def test_cols_iter():
 
     assert list(table.cols) == ["name", "c1", "c2"]
 
+
 def test_cols_get_index_unique():
     assert len(set(t.cols.get_index_unique())) == len(t)
+
 
 def test_cols_expression():
     data = {
@@ -278,20 +282,24 @@ def test_cols_expression():
     }
     table = Table(data)
     assert np.array_equal(table.cols["c1+c2"]["c1+c2"], data["c1"] + data["c2"])
-    assert np.array_equal(table.cols["c1+1.34"]["c1+1.34"], table["c1"]+1.34)
+    assert np.array_equal(table.cols["c1+1.34"]["c1+1.34"], table["c1"] + 1.34)
+
 
 ## Table rows tests
+
 
 def test_rows_get_index():
     assert t.rows.get_index("ip2::1") == 2
     assert t.rows.get_index("ip2") == 1
-    assert t.rows.get_index(("ip2",1)) == 2
+    assert t.rows.get_index(("ip2", 1)) == 2
+
 
 def test_rows_is_repeated():
     assert not t.rows.is_repeated("ip1")
     assert t.rows.is_repeated("ip2")
     assert not t.rows.is_repeated("ip3")
     assert not t.rows.is_repeated("tab$end")
+
 
 def test_rows_selection_indices():
     assert t.rows[1].betx[0] == data["betx"][1]
@@ -318,13 +326,21 @@ def test_rows_selection_ranges():
 def test_rows_multiple_selection():
     assert t.rows[t.s > 1, 1].betx[0] == data["betx"][t.s > 1][1]
 
+
 def test_rows_mask():
     assert np.array_equal(t.betx[t.rows.mask[:, t.s > 1]], data["betx"][t.s > 1])
     assert np.array_equal(t.betx[t.rows.mask[[2, 1]]], data["betx"][[1, 2]])
 
 
+def test_rows_indices():
+    assert np.array_equal(t.betx[t.rows.indices[[2, 1]]], data["betx"][[2, 1]])
+    assert np.array_equal(t.betx[t.rows.indices[t.s > 1]], data["betx"][t.s > 1])
+    assert np.array_equal(t.betx[t.rows.indices[:, t.s > 1]], data["betx"][t.s > 1])
+    assert np.array_equal(t.betx[t.rows.indices[1]], data["betx"][[1]])
+
 
 ## Table without index
+
 
 def test_table_no_index():
     data = {
@@ -340,8 +356,4 @@ def test_table_no_index():
 
     assert table["c1", 1] == data["c1"][1]
     assert np.array_equal(table["c1"], data["c1"])
-    assert np.array_equal(table["c1", [1, 2]], data["c1"][[1,2]])
-
-
-
-
+    assert np.array_equal(table["c1", [1, 2]], data["c1"][[1, 2]])

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -92,9 +92,9 @@ def _to_str(arr, digits, fixed="g", max_len=None):
 
 class _View:
     def __init__(self, data, index, nrows):
-        self.data = data # can be table or view
+        self.data = data  # can be table or view
         self.index = index
-        self.nrows = nrows # used only in case data is table
+        self.nrows = nrows  # used only in case data is table
 
     def __getitem__(self, k):
         return self.data[k][self.index]
@@ -334,7 +334,7 @@ class Table:
         """
         name, count, offset = self._split_name_count_offset(regexp)
         if count is not None:
-            tryidx=self._get_row_cache(name, count, offset)
+            tryidx = self._get_row_cache(name, count, offset)
             if tryidx is not None:
                 return np.array([tryidx], dtype=int)
         regexpr = re.compile(name, flags=self._regex_flags)
@@ -345,9 +345,9 @@ class Table:
                 iilst.append(ii)
                 nnlst.add(nn)
         if count is not None:
-            iilst=[]
+            iilst = []
             for nn in nnlst:
-                idx=self._get_row_cache(nn, count,0)
+                idx = self._get_row_cache(nn, count, 0)
                 if idx is not None:
                     iilst.append(idx)
         return np.array(iilst, dtype=int) + offset
@@ -547,9 +547,7 @@ class Table:
             if len(args) == 0:
                 col = None
                 row = None
-                raise KeyError(
-                    f"Empty selection for <Table id={id(self)}>."
-                )
+                raise KeyError(f"Empty selection for <Table id={id(self)}>.")
             elif len(args) == 1:
                 col = args[0]
                 row = None
@@ -580,9 +578,7 @@ class Table:
                     idx = row
                 return col[idx]
             else:
-                raise KeyError(
-                    f"Too many arguments {args} for <Table id={id(self)}>."
-                )
+                raise KeyError(f"Too many arguments {args} for <Table id={id(self)}>.")
         raise KeyError(f"Invalid arguments {args} for <Table id={id(self)}>.")
 
     def show(
@@ -713,7 +709,7 @@ class Table:
         ns = "s" if n != 1 else ""
         cs = "s" if c != 1 else ""
         out = [f"{self.__class__.__name__}: {n} row{ns}, {c} col{cs}"]
-        if n ==0:
+        if n == 0:
             pass
         elif n < 30:
             out.append(self.show(output=str, maxwidth="auto"))
@@ -824,7 +820,7 @@ class Table:
         return len(self._data[k])
 
     def __setitem__(self, key, val):
-        if key == self._index or key=="_sep_count":
+        if key == self._index or key == "_sep_count":
             object.__setattr__(self, "_index_cache", None)
             object.__setattr__(self, "_count_cache", None)
             object.__setattr__(self, "_name_cache", None)
@@ -934,7 +930,7 @@ class Indices:
 
     def __getitem__(self, rows):
         if isinstance(rows, tuple):  # multiple arguments
-            view_table=self.table.rows._make_view(*rows)
+            view_table = self.table.rows._make_view(*rows)
             return view_table._data.get_indices()
         else:
             index = self.table._get_row_indices(rows)
@@ -965,11 +961,13 @@ class _RowView:
         """
         Return a table with a restricted view of the rows.
         """
-        table=self.table
+        table = self.table
         for row in rows:
-            index=table._get_row_indices(row)
-            data=_View(table._data, index, len(table))
-            table=Table(data, col_names=table._col_names, index=table._index, verify=False)
+            index = table._get_row_indices(row)
+            data = _View(table._data, index, len(table))
+            table = Table(
+                data, col_names=table._col_names, index=table._index, verify=False
+            )
         return table
 
     def __getitem__(self, rows):
@@ -1026,13 +1024,11 @@ class _RowView:
         return self.table._get_row_index(row)
 
     def get_regexp_indices(self, regexp):
-        """Get indices using string selector on the index column.
-        """
+        """Get indices using string selector on the index column."""
         return self.table._get_regexp_indices(regexp)
- 
+
     def get_col_regexp_indices(self, regexp, col):
-        """Get indices using regular expression on the index column.
-        """
+        """Get indices using regular expression on the index column."""
         return self.table._get_col_regexp_indices(regexp, col)
 
 


### PR DESCRIPTION
## Description
Fix behavior of tt.rows[...,...] that should be equivalent to tt.rows[...].rows[...]...


Fix tests in xtrack
Closes # .

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
