### PR TITLE
support setitem on col row

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -3,18 +3,18 @@ import pytest
 
 from xdeps import Table
 
-data = {
-    "name": np.array(["ip1", "ip2", "ip2", "ip3", "tab$end"]),
-    "s": np.array([1.0, 2.0, 2.1, 3.0, 4.0]),
-    "betx": np.array([4.0, 5.0, 5.1, 6.0, 7.0]),
-    "bety": np.array([2.0, 3.0, 3.1, 4.0, 9.0]),
-}
 
+def get_a_table():
+    data = {
+        "name": np.array(["ip1", "ip2", "ip2", "ip3", "tab$end"]),
+        "s": np.array([1.0, 2.0, 2.1, 3.0, 4.0]),
+        "betx": np.array([4.0, 5.0, 5.1, 6.0, 7.0]),
+        "bety": np.array([2.0, 3.0, 3.1, 4.0, 9.0]),
+    }
+    t = Table(data)
+    return t, data
 
-## Table tests
-
-t = Table(data)
-
+t, data = get_a_table()
 
 def test_table_initialization():
     # Valid initialization
@@ -118,12 +118,15 @@ def test_table_getitem_edge_cases():
 
 
 def test_table_setitem_col():
+    t, data = get_a_table()
     t["2betx"] = t["betx"] * 2
     assert np.array_equal(t["2betx"], data["betx"] * 2)
     t["betx"] = 1
     assert np.array_equal(t["betx"], np.ones(len(data["betx"])))
 
+
 def test_table_setitem_col_row():
+    t, data = get_a_table()
     t["betx", 1] = 10
     assert t["betx", 1] == 10
     t["betx", "ip2"] = 20
@@ -152,6 +155,7 @@ def test_table_setitem_col_row():
     assert t["betx", "ip2::1>>1"] == 50
     t["betx", "ip2::1>>1"] = 50
     assert t["betx", "ip2::1>>1"] == 50
+
 
 def test_table_numpy_string():
     tab = Table(dict(name=np.array(["a", "b$b"]), val=np.array([1, 2])))
@@ -276,6 +280,29 @@ def test_table_show():
     data = {"name": np.array(["a", "b", "c"]), "value": np.array([1, 2, 3])}
     table = Table(data)
     assert table.show(output=str) == "name value\na        1\nb        2\nc        3"
+
+
+def test_table_show_rows():
+    data = {"name": np.array(["a", "b", "c"]), "value": np.array([1, 2, 3])}
+    table = Table(data)
+    assert table.show(rows=1, output=str) == "name value\nb        2"
+
+
+def test_table_show_cols():
+    data = {"name": np.array(["a", "b", "c"]), "value": np.array([1, 2, 3])}
+    table = Table(data)
+    assert (
+        table.show(cols="value", output=str)
+        == "name value\na        1\nb        2\nc        3"
+    )
+
+
+def test_table_show_rows_cols():
+    t, data = get_a_table()
+    assert (
+        t.show(rows="ip2.*", cols="betx", output=str)
+        == "name            betx\nip1                5\nip2::0           5.1"
+    )
 
 
 ## Table cols tests

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -117,6 +117,42 @@ def test_table_getitem_edge_cases():
     assert t[("betx",)][2] == t["betx"][2]
 
 
+def test_table_setitem_col():
+    t["2betx"] = t["betx"] * 2
+    assert np.array_equal(t["2betx"], data["betx"] * 2)
+    t["betx"] = 1
+    assert np.array_equal(t["betx"], np.ones(len(data["betx"])))
+
+def test_table_setitem_col_row():
+    t["betx", 1] = 10
+    assert t["betx", 1] == 10
+    t["betx", "ip2"] = 20
+    assert t["betx", "ip2"] == 20
+    t["betx", "ip2::1"] = 30
+    assert t["betx", "ip2::1"] == 30
+    t["betx", "ip2<<1"] = 40
+    assert t["betx", "ip2<<1"] == 40
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+    t["betx", "ip2::1>>1"] = 50
+    assert t["betx", "ip2::1>>1"] == 50
+
 def test_table_numpy_string():
     tab = Table(dict(name=np.array(["a", "b$b"]), val=np.array([1, 2])))
     assert tab["val", tab.name[1]] == 2

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -443,6 +443,8 @@ class Table:
                 return np.array(out, dtype=int)
             else:
                 raise ValueError(f"Invalid row selector {row}")
+        elif row is None:
+            return slice(None)
         else:
             return [self._get_row_index(row)]
 

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -543,7 +543,7 @@ class Table:
                 return self._data[args]
             except KeyError:
                 return eval(args, gblmath, self._data)
-        if type(args) is tuple:  # multiple args
+        if isinstance(args,tuple):  # multiple args
             if len(args) == 0:
                 col = None
                 row = None
@@ -824,14 +824,38 @@ class Table:
             object.__setattr__(self, "_index_cache", None)
             object.__setattr__(self, "_count_cache", None)
             object.__setattr__(self, "_name_cache", None)
-        if key in self.__dict__:
-            object.__setattr__(self, key, val)
-        elif key in self._col_names:
-            self._data[key][:] = val
+        elif isinstance(key, str):
+            if key in self.__dict__:
+                object.__setattr__(self, key, val)
+            elif key in self._col_names:
+                self._data[key][:] = val
+            else:
+                self._data[key] = val
+                if hasattr(val, "__iter__") and len(val) == len(self):
+                    self._col_names.append(key)
+        elif isinstance(key,tuple):
+            col,row = key
+            col = self._data[col]
+            if isinstance(row, str):
+                cache, count = self._get_cache()
+                idx = cache.get((row, 0))
+                if idx is None:
+                    name, count, offset = self._split_name_count_offset(row)
+                    idx = self._get_row_cache_raise(name, count, offset)
+            elif isinstance(row, tuple):
+                cache, count = self._get_cache()
+                idx = cache.get(row)
+                if idx is None:
+                    idx = self._get_row_cache_raise(*row)
+            elif isinstance(row, slice):
+                idx = self._get_row_indices(row)
+            elif isinstance(row, list):
+                idx = self._get_row_indices(row)
+            else:
+                idx = row
+            col[idx]=val
         else:
-            self._data[key] = val
-            if hasattr(val, "__iter__") and len(val) == len(self):
-                self._col_names.append(key)
+            raise ValueError(f"Invalid key {key}")
 
     __setattr__ = __setitem__
 

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -477,7 +477,10 @@ class Table:
             col_list.insert(0, self._index)
         data = {}
         for cc in col_list:
-            data[cc] = eval(cc, gblmath, view)
+            try:
+                data[cc] = view[cc]
+            except KeyError:
+                data[cc] = eval(cc, gblmath, view)
         for kk in self.keys(exclude_columns=True):
             data[kk] = self._data[kk]
         return self.__class__(


### PR DESCRIPTION
## Description
Support `t["betx","ip1"]=3` and variants

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
