### PR TITLE
Release/0.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,2 @@
 [build-system]
 requires = ["setuptools", "wheel", "Cython"]
-
-[project]
-requires-python = ">= 3.8"

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -123,6 +123,8 @@ def test_table_setitem_col():
     assert np.array_equal(t["2betx"], data["betx"] * 2)
     t["betx"] = 1
     assert np.array_equal(t["betx"], np.ones(len(data["betx"])))
+    t["name"] = t["name"] * 2
+    assert np.all(t['name'] == [x * 2 for x in data['name']])
 
 
 def test_table_setitem_col_row():

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -829,7 +829,8 @@ class Table:
             object.__setattr__(self, "_index_cache", None)
             object.__setattr__(self, "_count_cache", None)
             object.__setattr__(self, "_name_cache", None)
-        elif isinstance(key, str):
+
+        if isinstance(key, str):
             if key in self.__dict__:
                 object.__setattr__(self, key, val)
             elif key in self._col_names:


### PR DESCRIPTION
**Changes:**

- Support expressions such as `t["betx","ip1"] = 3` (setitem) #85 
- Don't build wheels for Python 3.7 #87 