### PR TITLE
Add a flag to decide if overwriting is desired in copy_from_expr

### DIFF
--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -107,7 +107,7 @@ class CompactFormatter:
     def repr_item(self, owner, key):
         if not isinstance(owner, Ref) and owner != self.scope:
             raise ValueError(
-                f'Cannot represent `{owner!r}[{key!r}]` in XMad syntax. '
+                f'Cannot represent `{owner!r}[{key!r}]` in compact syntax. '
                 f'Only top-level Ref elements are representable, but '
                 f'scope={self.scope}.'
             )


### PR DESCRIPTION
## Description

- Add an option `overwrite` in `Manager.copy_from_expr` that allows to decide whether the incoming expressions should overwrite existing ones or not. Default behaviour is unchanged.
- Make `Manager._run_tasks` public. Currently to achieve almost the same behaviour on the (xtrack) side we do some complicated logic. Since I need this in an upcoming xtrack PR, I think it's nice to simply expose this.
- Some minor other fixes (typos + bug in `copy_from_expr` that was apparent when the references had expressions dependent on the same container).

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
