### PR TITLE
Release/0.9.0

### DIFF
--- a/xdeps/refs.py
+++ b/xdeps/refs.py
@@ -107,7 +107,7 @@ class CompactFormatter:
     def repr_item(self, owner, key):
         if not isinstance(owner, Ref) and owner != self.scope:
             raise ValueError(
-                f'Cannot represent `{owner!r}[{key!r}]` in XMad syntax. '
+                f'Cannot represent `{owner!r}[{key!r}]` in compact syntax. '
                 f'Only top-level Ref elements are representable, but '
                 f'scope={self.scope}.'
             )

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -505,7 +505,7 @@ class Table:
             data[kk] = self._data[kk]
         return self.__class__(
             data,
-            col_names=self._col_names,
+            col_names=self._col_names.copy(),
             index=self._index,
             sep_count=self._sep_count,
             sep_previous=self._sep_previous,
@@ -526,7 +526,7 @@ class Table:
             data[self._index] = self._data[self._index]
         return self.__class__(
             data,
-            col_names=cols,
+            col_names=list(cols).copy(),
             index=self._index,
             sep_count=self._sep_count,
             sep_previous=self._sep_previous,

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -754,6 +754,21 @@ class Table:
         return cls(data, col_names=col_names, index=index)
 
     @classmethod
+    def concatenate(cls, tables):
+        """Concatenate a list of tables."""
+
+        # Use only common columns
+        col_names = set(tables[0]._col_names)
+        for tt in tables[1:]:
+            col_names &= set(tt._col_names)
+
+        data = {}
+        for cc in col_names:
+            data[cc] = np.concatenate([tt[cc] for tt in tables])
+
+        return cls(data)
+
+    @classmethod
     def from_csv(cls, filename, index=None, **kwargs):
         import pandas as pd
 


### PR DESCRIPTION
**Changes:**

- Flag `overwrite` added to `Manager.copy_from_expr`. If `True` (default), overwrite existing tasks with the same target. Otherwise, leave the existing task untouched.
- Add a new method `Table.concatenate` to join tables.