### PR TITLE
Build Xdeps wheels for different platforms in parallel

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, macos-14]
+        pyver: [cp38, cp39, cp310, cp311, cp312, cp313]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +25,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
+          CIBW_BUILD: ${{ matrix.pyver }}-*
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

Speed up building of Xdeps wheels by parallelising the process not only over OSs but also Python versions. Add a build for CPython 3.13, and stop making builds for PyPy because Xsuite wheels are also not compatible with it, so there's no reason to do it.