### PR TITLE
Display python version in deploy jobs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-wheels:
-    name: Build wheels for ${{ matrix.os }}
+    name: Build wheels for ${{ matrix.pyver }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
## Description

Display also the python version next to the os in job titles when building wheels: a very minor quality of life improvement.