### PR TITLE
Take best only if a solution has not been found

### DIFF
--- a/xdeps/optimize/optimize.py
+++ b/xdeps/optimize/optimize.py
@@ -1054,7 +1054,7 @@ class Optimize:
             if self._err.last_point_within_tol:
                 break
 
-        if take_best:
+        if take_best and not self._err.last_point_within_tol:
             penalty_step = self._log["penalty"][i_log_start:]
             i_best = np.argmin(penalty_step)
             if i_best != len(penalty_step) - 1:


### PR DESCRIPTION
## Description
Change the definition of take_best

Previously the behaviour was that take_best would override a solution that had been found if a penalty was lower elsewhere.
It is not always true that the penalty is minimum at a valid solution point.
This fix changes the behaviour to only take_best when a solution within tolerance has not been found

Closes xsuite/xsuite#589

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
