### PR TITLE
Unpin the version of cibuildwheel in deploy.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.5
+        run: python -m pip install cibuildwheel
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
## Description

Apparently pinning a version is not safe, because older versions of dependencies might stop existing...
