### PR TITLE
Fix/table iter

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -422,3 +422,16 @@ def test_table_no_index():
     assert table["c1", 1] == data["c1"][1]
     assert np.array_equal(table["c1"], data["c1"])
     assert np.array_equal(table["c1", [1, 2]], data["c1"][[1, 2]])
+
+def test_table_row_iter_underscore():
+
+    Table(data={'name':np.array([1,2,3]), '_b':np.array([1,2,3])})
+    tt = Table(data={'name':np.array([1,2,3]), '_b':np.array([1,2,3])})
+    b_from_iter = []
+    rows = []
+    for rr in tt.rows:
+        b_from_iter.append(rr._b)
+        rows.append(rr)
+
+    table2 = Table.from_rows(rows, index='name')
+    table2.show()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -426,12 +426,19 @@ def test_table_no_index():
 def test_table_row_iter_underscore():
 
     Table(data={'name':np.array([1,2,3]), '_b':np.array([1,2,3])})
-    tt = Table(data={'name':np.array([1,2,3]), '_b':np.array([1,2,3])})
+    tt = Table(data={'name':np.array(['a','b','c']), '_b':np.array([1,2,3])})
     b_from_iter = []
     rows = []
     for rr in tt.rows:
+        assert rr.__class__.__name__ == 'Row'
         b_from_iter.append(rr._b)
         rows.append(rr)
 
+    assert np.all(np.array(b_from_iter) == [1,2,3])
+
     table2 = Table.from_rows(rows, index='name')
-    table2.show()
+    assert np.all(table2._data['_b'] == [1,2,3])
+
+    rb = table2.rows.at('b')
+    assert rb.name == 'b'
+    assert rb._b == 2

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import re
 from typing import Collection
-from collections import namedtuple
+from dataclasses import make_dataclass
 
 import numpy as np
 
@@ -160,7 +160,7 @@ class Table:
 
     Row view API:
 
-    - `table.rows.at(index, as_dict=False)` : get a row as a namedtuple or dictionary
+    - `table.rows.at(index, as_dict=False)` : get a row as a dataclass or dictionary
     - `table.rows.head(n=5)` : get the first n rows
     - `table.rows.tail(n=5)` : get the last n rows
     - `table.rows.reverse()` : reverse the order of the rows
@@ -194,7 +194,7 @@ class Table:
         self,
         data,
         col_names=None,
-        index="name",
+        index='name',
         sep_count="::",
         sep_previous="<<",
         sep_next=">>",
@@ -203,6 +203,7 @@ class Table:
         verify=True,
         _copy_cols=False,
     ):
+
         if verify:
             _data = data.copy()
             _col_names = list(data.keys() if col_names is None else col_names)
@@ -786,13 +787,18 @@ class Table:
 
     @classmethod
     def from_rows(cls, rows, col_names=None, index=None):
-        if hasattr(rows[0], "_asdict"):  # namedtuple
+        first = rows[0]
+        if hasattr(first, "_asdict"):  # namedtuple
             if col_names is None:
-                col_names = list(rows[0]._fields)
+                col_names = list(first._fields)
+            data = {cc: np.array([getattr(rr, cc) for rr in rows]) for cc in col_names}
+        elif hasattr(first, "__dataclass_fields__"):  # dataclass
+            if col_names is None:
+                col_names = list(first.__dataclass_fields__.keys())
             data = {cc: np.array([getattr(rr, cc) for rr in rows]) for cc in col_names}
         else:
             if col_names is None:
-                col_names = list(rows[0].keys())
+                col_names = list(first.keys())
             data = {cc: np.array([rr[cc] for rr in rows]) for cc in col_names}
         return cls(data, col_names=col_names, index=index)
 
@@ -1029,7 +1035,7 @@ class _RowView:
         return self.table._select_rows(indices)
 
     def __iter__(self):
-        res_type = namedtuple("Row", self.table._col_names)
+        res_type = make_dataclass("Row", self.table._col_names)
         for ii in range(len(self.table)):
             yield res_type(*[self.table[cc, ii] for cc in self.table._col_names])
 
@@ -1037,7 +1043,7 @@ class _RowView:
         if as_dict:
             return {cc: self.table[cc, index] for cc in self.table._col_names}
         else:
-            res_type = namedtuple("Row", self.table._col_names)
+            res_type = make_dataclass("Row", self.table._col_names)
             return res_type(*[self.table[cc, index] for cc in self.table._col_names])
 
     def transpose(self):


### PR DESCRIPTION
Use dataclass instead of namedtuple in `Table.at(...)` and `Table.__iter__()`. Support dataclasse in `Table.from_rows(...)`