### PR TITLE
fix show with rows

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -303,7 +303,7 @@ def test_table_show_rows_cols():
     t, data = get_a_table()
     assert (
         t.show(rows="ip2.*", cols="betx", output=str)
-        == "name            betx\nip1                5\nip2::0           5.1"
+        == "name            betx\nip2::0             5\nip2::1           5.1"
     )
 
 

--- a/xdeps/table.py
+++ b/xdeps/table.py
@@ -638,7 +638,7 @@ class Table:
             view = self
         else:
             view = self._select(rows, cols)
-            indices = view._get_row_indices(rows)
+            indices = self._get_row_indices(rows)
             unique = unique[indices]
 
         col_list = view._col_names


### PR DESCRIPTION
## Description
When using show with rows argument, the index column shows wrong names.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
